### PR TITLE
Datadog integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Add your Datadog API key if you are using the Datadog service
+# DD_API_KEY=[your API key here]
+

--- a/README.md
+++ b/README.md
@@ -28,6 +28,19 @@ and stop the services like this:
 ```
 docker-compose -f docker-compose.yml -f docker-compose-grafana-prometheus.yml down
 ```
+#### Running with Datadog
+Alternatively you can run the service with a Grafana integration.  This will require a Datadog API key.
+
+Copy `.env.example` to a new file named `.env`, uncomment the line containing `DD_API_KEY`, and add your key.
+
+Start the services with this command:
+```
+docker-compose -f docker-compose-datadog.yml up
+```
+and stop the services like this:
+```
+docker-compose -f docker-compose-datadog.yml down
+```
 ### Testing
 **NOTE:** the service handles requests for these domains:
 1. example.com

--- a/configs/datadog/gunicorn/conf.yaml
+++ b/configs/datadog/gunicorn/conf.yaml
@@ -1,0 +1,103 @@
+## All options defined here are available to all instances.
+#
+init_config:
+
+    ## @param gunicorn - string - optional - default: gunicorn
+    ## Command or path to gunicorn (e.g. `/usr/local/bin/gunicorn` or `docker exec container gunicorn`)
+    ## can be overwritten on an instance
+    #
+    # gunicorn: gunicorn
+
+    ## @param service - string - optional
+    ## Attach the tag `service:<SERVICE>` to every metric, event, and service check emitted by this integration.
+    ##
+    ## Additionally, this sets the default `service` for every log source.
+    #
+    # service: <SERVICE>
+
+## Every instance is scheduled independently of the others.
+#
+instances:
+
+    ## @param proc_name - string - required
+    ## The name of the gunicorn process. For the following gunicorn server:
+    ##
+    ## gunicorn --name <WEB_APP_NAME> <WEB_APP_CONFIG>.ini
+    ##
+    ## the name is `<WEB_APP_NAME>`
+    #
+  - proc_name: myapp:app
+
+    ## @param gunicorn - string - optional - default: gunicorn
+    ## Command or path to gunicorn (e.g. `/usr/local/bin/gunicorn` or `docker exec container gunicorn`)
+    #
+    # gunicorn: gunicorn
+
+    ## @param tags - list of strings - optional
+    ## A list of tags to attach to every metric and service check emitted by this instance.
+    ##
+    ## Learn more about tagging at https://docs.datadoghq.com/tagging
+    #
+    # tags:
+    #   - <KEY_1>:<VALUE_1>
+    #   - <KEY_2>:<VALUE_2>
+
+    ## @param service - string - optional
+    ## Attach the tag `service:<SERVICE>` to every metric, event, and service check emitted by this integration.
+    ##
+    ## Overrides any `service` defined in the `init_config` section.
+    #
+    # service: <SERVICE>
+
+    ## @param min_collection_interval - number - optional - default: 15
+    ## This changes the collection interval of the check. For more information, see:
+    ## https://docs.datadoghq.com/developers/write_agent_check/#collection-interval
+    #
+    # min_collection_interval: 15
+
+    ## @param empty_default_hostname - boolean - optional - default: false
+    ## This forces the check to send metrics with no hostname.
+    ##
+    ## This is useful for cluster-level checks.
+    #
+    # empty_default_hostname: false
+
+    ## @param metric_patterns - mapping - optional
+    ## A mapping of metrics to include or exclude, with each entry being a regular expression.
+    ##
+    ## Metrics defined in `exclude` will take precedence in case of overlap.
+    #
+    # metric_patterns:
+    #   include:
+    #   - <INCLUDE_REGEX>
+    #   exclude:
+    #   - <EXCLUDE_REGEX>
+
+## Log Section
+##
+## type - required - Type of log input source (tcp / udp / file / windows_event).
+## port / path / channel_path - required - Set port if type is tcp or udp.
+##                                         Set path if type is file.
+##                                         Set channel_path if type is windows_event.
+## source  - required - Attribute that defines which integration sent the logs.
+## encoding - optional - For file specifies the file encoding. Default is utf-8. Other
+##                       possible values are utf-16-le and utf-16-be.
+## service - optional - The name of the service that generates the log.
+##                      Overrides any `service` defined in the `init_config` section.
+## tags - optional - Add tags to the collected logs.
+##
+## Discover Datadog log collection: https://docs.datadoghq.com/logs/log_collection/
+#
+logs:
+  - type: file
+    path: /var/log/gunicorn/access.log
+    service: myapp
+    source: gunicorn
+  - type: file
+    path: /var/log/gunicorn/error.log
+    service: myapp
+    source: gunicorn
+    log_processing_rules:
+    - type: multi_line
+      name: log_start_with_date
+      pattern: \[\d{4}-\d{2}-\d{2}

--- a/docker-compose-datadog.yml
+++ b/docker-compose-datadog.yml
@@ -4,6 +4,8 @@ services:
     extends:
       file: docker-compose.yml
       service: statsd-exporter
+    command:
+      - --statsd.relay.address=datadog-agent:8125
   datadog-agent:
     image: 'datadog/agent:7.31.1'
     environment:

--- a/docker-compose-datadog.yml
+++ b/docker-compose-datadog.yml
@@ -1,0 +1,63 @@
+version: "3.9"
+services:
+  statsd-exporter:
+    extends:
+      file: docker-compose.yml
+      service: statsd-exporter
+  datadog-agent:
+    image: 'datadog/agent:7.31.1'
+    environment:
+      - DD_API_KEY=${DD_API_KEY}
+      - DD_LOGS_ENABLED=true
+      - DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL=true
+      - DD_CONTAINER_EXCLUDE="name:datadog-agent"
+      - DD_PROCESS_AGENT_ENABLED=true
+      - DD_DOCKER_LABELS_AS_TAGS={"my.custom.label.team":"team"}
+      - DD_TAGS='env:dd101-dev'
+      - DD_HOSTNAME=dd101-dev-host
+      - DD_DOGSTATSD_NON_LOCAL_TRAFFIC=true
+      - DD_APM_NON_LOCAL_TRAFFIC=true
+    ports:
+      - 8125:8125/udp
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - /proc/:/host/proc/:ro
+      - /sys/fs/cgroup/:/host/sys/fs/cgroup:ro
+  myapp:
+    extends:
+      file: docker-compose.yml
+      service: myapp
+    labels:
+      com.datadoghq.tags.env: 'prod'
+      com.datadoghq.tags.service: 'myapp'
+      com.datadoghq.tags.version: '2.1'
+      my.custom.label.team: 'myapp'
+      com.datadoghq.ad.check_names: '["gunicorn"]'
+      com.datadoghq.ad.init_configs: '[{}]'
+        #com.datadoghq.ad.instances: '[{"host":"%%host%%", "port":8000,"username":"datadog","password":"datadog"}]'
+      com.datadoghq.ad.instances: '[{"host":"%%host%%", "port":8000}]'
+      com.datadoghq.ad.logs: '[{"source": "gunicorn", "service": "myapp"}]'
+      com.datadog.ad.proc_name: 'myapp'
+  db:
+    extends:
+      file: docker-compose.yml
+      service: db
+    depends_on:
+      - datadog-agent
+    labels:
+      com.datadoghq.ad.check_names: '["mysql"]'
+      com.datadoghq.ad.init_configs: '[{}]'
+      com.datadoghq.ad.instances: '[{"host":"%%host%%", "port":3306,"username":"datadog","password":"datadog"}]'
+      com.datadoghq.ad.logs: '[{"source": "mysql", "service": "db"}]'
+  mock-elb:
+    extends:
+      file: docker-compose.yml
+      service: mock-elb
+    labels:
+      com.datadoghq.ad.check_names: '["nginx"]'
+      com.datadoghq.ad.init_configs: '[{}]'
+      com.datadoghq.ad.instances: '[{"nginx_status_url": "http://%%host%%:80/nginx_status/"}]'
+      com.datadoghq.ad.logs: '[{"source":"nginx","service":"mock-elb"}]'
+
+volumes:
+  dbdata:

--- a/docker-compose-datadog.yml
+++ b/docker-compose-datadog.yml
@@ -10,34 +10,34 @@ services:
       - DD_API_KEY=${DD_API_KEY}
       - DD_LOGS_ENABLED=true
       - DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL=true
-      - DD_CONTAINER_EXCLUDE="name:datadog-agent"
+      - DD_LOGS_CONFIG_USE_HTTP=true
+      - DD_CONTAINER_EXCLUDE_LOGS=name:datadog-agent
       - DD_PROCESS_AGENT_ENABLED=true
-      - DD_DOCKER_LABELS_AS_TAGS={"my.custom.label.team":"team"}
-      - DD_TAGS='env:dd101-dev'
-      - DD_HOSTNAME=dd101-dev-host
       - DD_DOGSTATSD_NON_LOCAL_TRAFFIC=true
-      - DD_APM_NON_LOCAL_TRAFFIC=true
     ports:
       - 8125:8125/udp
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
       - /proc/:/host/proc/:ro
       - /sys/fs/cgroup/:/host/sys/fs/cgroup:ro
+      - type: bind
+        source: configs/datadog/gunicorn/conf.yaml
+        target: /etc/datadog-agent/conf.d/gunicorn.d/conf.yaml
+      - type: volume
+        source: gunicorn_logs
+        target: /var/log/gunicorn
+        read_only: true
   myapp:
     extends:
       file: docker-compose.yml
       service: myapp
-    labels:
-      com.datadoghq.tags.env: 'prod'
-      com.datadoghq.tags.service: 'myapp'
-      com.datadoghq.tags.version: '2.1'
-      my.custom.label.team: 'myapp'
-      com.datadoghq.ad.check_names: '["gunicorn"]'
-      com.datadoghq.ad.init_configs: '[{}]'
-        #com.datadoghq.ad.instances: '[{"host":"%%host%%", "port":8000,"username":"datadog","password":"datadog"}]'
-      com.datadoghq.ad.instances: '[{"host":"%%host%%", "port":8000}]'
-      com.datadoghq.ad.logs: '[{"source": "gunicorn", "service": "myapp"}]'
-      com.datadog.ad.proc_name: 'myapp'
+    volumes:
+      - type: volume
+        source: gunicorn_logs
+        target: /var/log/gunicorn
+      - type: bind
+        source: ./web/myapp/gunicorn-log-to-disk.conf.py
+        target: /app/gunicorn.conf.py
   db:
     extends:
       file: docker-compose.yml
@@ -61,3 +61,4 @@ services:
 
 volumes:
   dbdata:
+  gunicorn_logs:

--- a/web/myapp/gunicorn-log-to-disk.conf.py
+++ b/web/myapp/gunicorn-log-to-disk.conf.py
@@ -1,0 +1,12 @@
+# Gunicorn config variables
+loglevel = "info"
+errorlog = "/var/log/gunicorn/error.log"
+accesslog = "/var/log/gunicorn/access.log"
+worker_tmp_dir = "/dev/shm"
+graceful_timeout = 120
+timeout = 120
+keepalive = 5
+threads = 3
+bind = "0.0.0.0:8000"
+statsd_host = "statsd-exporter:9125"
+statsd_prefix = "myapp"


### PR DESCRIPTION
Optionally configure the example app to send logs and metrics to Datadog for Nginx, Gunicorn, and MySQL. 